### PR TITLE
Declare M4 includes in acinclude.m4

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -1,0 +1,3 @@
+m4_include([m4/carbon.m4])
+m4_include([m4/display.m4])
+m4_include([m4/util.m4])


### PR DESCRIPTION
The various functions that configure.in relies on need to be declared
in acinclude.m4.

Signed-off-by: Stephen Kitt <steve@sk2.org>