### PR TITLE
Fix the argument used to check stack depth in @throw

### DIFF
--- a/src/zcode.ops
+++ b/src/zcode.ops
@@ -724,7 +724,7 @@ OPCODE "throw"        2OP:0x1c CANJUMP       VERSION 5,6,7,8
 %{
   if (stack->current_frame == NULL)
     zmachine_fatal("Throw attempted after function with catch has returned");
-  if (stack->current_frame->frame_num < arg1)
+  if (stack->current_frame->frame_num < arg2)
     zmachine_fatal("Throw attempted after function with catch has returned");
 
   /* Unroll the stack to the appropriate frame */


### PR DESCRIPTION
For @throw, arg1 is the return value, and arg2 is the stack frame to
return to (i.e. a value returned by @catch).