### PR TITLE
Preference window improvements.

### DIFF
--- a/src/zoomCocoa/ZoomPreferenceWindow.m
+++ b/src/zoomCocoa/ZoomPreferenceWindow.m
@@ -44,17 +44,17 @@ static NSDictionary*  itemDictionary = nil;
 	
 	// Set up the items
 	[generalSettingsItem setLabel: @"General"];
-	[generalSettingsItem setImage: [[[NSImage alloc] initWithContentsOfFile: [[NSBundle mainBundle] pathForImageResource: @"generalSettings"]] autorelease]];
+	[generalSettingsItem setImage: [NSImage imageNamed: @"generalSettings"]];
 	[gameSettingsItem setLabel: @"Game"];
-	[gameSettingsItem setImage: [[[NSImage alloc] initWithContentsOfFile: [[NSBundle mainBundle] pathForImageResource: @"gameSettings"]] autorelease]];
+	[gameSettingsItem setImage: [NSImage imageNamed: @"gameSettings"]];
 	[displaySettingsItem setLabel: @"Display"];
-	[displaySettingsItem setImage: [[[NSImage alloc] initWithContentsOfFile: [[NSBundle mainBundle] pathForImageResource: @"displaySettings"]] autorelease]];
+	[displaySettingsItem setImage: [NSImage imageNamed: @"displaySettings"]];
 	[fontSettingsItem setLabel: @"Fonts"];
-	[fontSettingsItem setImage: [[[NSImage alloc] initWithContentsOfFile: [[NSBundle mainBundle] pathForImageResource: @"fontSettings"]] autorelease]];
+	[fontSettingsItem setImage: [NSImage imageNamed: @"fontSettings"]];
 	[colourSettingsItem setLabel: @"Colour"];
-	[colourSettingsItem setImage: [[[NSImage alloc] initWithContentsOfFile: [[NSBundle mainBundle] pathForImageResource: @"colourSettings"]] autorelease]];
+	[colourSettingsItem setImage: [NSImage imageNamed: NSImageNameColorPanel]];
 	[typographicSettingsItem setLabel: @"Typography"];
-	[typographicSettingsItem setImage: [[[NSImage alloc] initWithContentsOfFile: [[NSBundle mainBundle] pathForImageResource: @"typographicSettings"]] autorelease]];
+	[typographicSettingsItem setImage: [NSImage imageNamed: @"typographicSettings"]];
 	
 	// And the actions
 	[generalSettingsItem setAction: @selector(generalSettings:)];

--- a/src/zoomCocoa/ZoomPreferenceWindow.m
+++ b/src/zoomCocoa/ZoomPreferenceWindow.m
@@ -135,7 +135,10 @@ static int familyComparer(id a, id b, void* context) {
 	[toolbar setAllowsUserCustomization: NO];
 	
 	[[self window] setToolbar: toolbar];
-	
+	if (@available(macOS 11.0, *)) {
+		self.window.toolbarStyle = NSWindowToolbarStylePreference;
+	}
+
 	[[self window] setContentSize: [generalSettingsView frame].size];
 	[[self window] setContentView: generalSettingsView];
 


### PR DESCRIPTION
Set the toolbar style of the preferences to `NSWindowToolbarStylePreference`.
* This makes the preference window look like a preference window on Big Sur and later, with the icons under the window title.

Replace the convoluted NSImage getters to just `imageNamed:`
* This can allow for such things as Retina images, Xcode assets, and even system images (`NSImageNameColorPanel`).