### PR TITLE
Pixmap fix

### DIFF
--- a/src/zoomCocoa/ZoomPixmapWindow.h
+++ b/src/zoomCocoa/ZoomPixmapWindow.h
@@ -20,14 +20,14 @@
 
 // Initialisation
 - (id) initWithZoomView: (ZoomView*) view;
-- (void) setZoomView: (ZoomView*) view;
+@property (assign) ZoomView* zoomView;
 
 // Getting the pixmap
-- (NSSize) size;
-- (NSImage*) pixmap;
+@property (readonly) NSSize size;
+@property (readonly, retain) NSImage *pixmap;
 
 // Input information
-- (NSPoint) inputPos;
+@property (readonly) NSPoint inputPos;
 - (ZStyle*) inputStyle;
 
 @end

--- a/src/zoomCocoa/ZoomPixmapWindow.m
+++ b/src/zoomCocoa/ZoomPixmapWindow.m
@@ -6,6 +6,7 @@
 //  Copyright (c) 2004 Andrew Hunter. All rights reserved.
 //
 
+#include <tgmath.h>
 #import "ZoomPixmapWindow.h"
 
 
@@ -39,9 +40,7 @@
 	return [pixmap size];
 }
 
-- (NSImage*) pixmap {
-	return pixmap;
-}
+@synthesize pixmap;
 
 // = Standard window commands =
 
@@ -63,10 +62,10 @@
     NSLayoutManager* layoutManager = [[NSLayoutManager alloc] init];
     
     // Width is one 'em'
-    float width = [@"M" sizeWithAttributes: [NSDictionary dictionaryWithObjectsAndKeys: NSFontAttributeName, font, nil]].width;
+	CGFloat width = [@"M" sizeWithAttributes: [NSDictionary dictionaryWithObjectsAndKeys: NSFontAttributeName, font, nil]].width;
     
     // Height is decided by the layout manager
-    float height = [layoutManager defaultLineHeightForFont: font];
+	CGFloat height = [layoutManager defaultLineHeightForFont: font];
     
     return NSMakeSize(width, height);
 }
@@ -112,11 +111,11 @@
 	NSMutableDictionary* attr = [[zView attributesForStyle: style] mutableCopy];
 	
 	// Draw the background
-	float height = [self sizeOfFont: [attr objectForKey: NSFontAttributeName]].height;
-	float descender = [[attr objectForKey: NSFontAttributeName] descender];
+	CGFloat height = [self sizeOfFont: [attr objectForKey: NSFontAttributeName]].height;
+	CGFloat descender = [[attr objectForKey: NSFontAttributeName] descender];
 	NSSize size = [text sizeWithAttributes: attr];
 	
-	point.y -= ceilf(height)+1.0;
+	point.y -= ceil(height)+1.0;
 	
 	size.height = height;
 	NSRect backgroundRect;
@@ -124,10 +123,10 @@
 	backgroundRect.size = size;
 	backgroundRect.origin.y -= descender;
 	
-	backgroundRect.origin.x = floorf(backgroundRect.origin.x);
-	backgroundRect.origin.y = floorf(backgroundRect.origin.y);
-	backgroundRect.size.width = ceilf(backgroundRect.size.width);
-	backgroundRect.size.height = ceilf(backgroundRect.size.height) + 1.0;
+	backgroundRect.origin.x = floor(backgroundRect.origin.x);
+	backgroundRect.origin.y = floor(backgroundRect.origin.y);
+	backgroundRect.size.width = ceil(backgroundRect.size.width);
+	backgroundRect.size.height = ceil(backgroundRect.size.height) + 1.0;
 	
 	[(NSColor*)[attr objectForKey: NSBackgroundColorAttributeName] set];
 	NSRectFill(backgroundRect);
@@ -152,14 +151,15 @@
 	NSBitmapImageRep*	copiedBits	= [[NSBitmapImageRep alloc] initWithFocusedViewRect: region];
 	NSImage*			copiedImage	= [[NSImage alloc] init];
 	[copiedImage addRepresentation: copiedBits];
+	[copiedBits release];
 	[copiedImage drawInRect: NSMakeRect(where.x, where.y, region.size.width, region.size.height)
 				   fromRect: NSMakeRect(0,0, region.size.width, region.size.height)
-				  operation: NSCompositeSourceOver
+				  operation: NSCompositingOperationSourceOver
 				   fraction: 1.0
 			 respectFlipped: YES
 					  hints: nil];
 	
-	[copiedBits release];
+	[copiedImage release];
 	
 	// Uh, docs say we should use NSNullObject here, but it's not defined. Making a guess at its value (sigh)
 	// This would be less of a problem in a view, because we can get the view's own graphics state. But you
@@ -227,9 +227,7 @@
 	inputStyle = [style copy];
 }
 
-- (NSPoint) inputPos {
-	return inputPos;
-}
+@synthesize inputPos;
 
 - (ZStyle*) inputStyle {
 	return inputStyle;
@@ -239,10 +237,6 @@
 					 atPoint: (NSPoint) point {
 	NSImage* img = [[zView resources] imageWithNumber: number];
 
-	NSRect imgRect;
-	imgRect.origin = NSMakePoint(0,0);
-	imgRect.size = [img size];
-	
 	NSRect destRect;
 	destRect.origin = point;
 	destRect.size = [[zView resources] sizeForImageWithNumber: number
@@ -250,8 +244,8 @@
 	
 	[pixmap lockFocusFlipped:YES];
 	[img drawInRect: destRect
-		   fromRect: imgRect
-		  operation: NSCompositeSourceOver
+		   fromRect: NSZeroRect
+		  operation: NSCompositingOperationSourceOver
 		   fraction: 1.0
 	 respectFlipped: YES
 			  hints: nil];
@@ -280,9 +274,7 @@
     return self;
 }
 
-- (void) setZoomView: (ZoomView*) view {
-	zView = view;
-}
+@synthesize zoomView=zView;
 
 // = Input styles =
 


### PR DESCRIPTION
These commits are based off of my attempts to get Zork Zero to work on my fork while also modernizing the code.
These include:
* flipping the context instead of the image.
* setting the initial pixmap size to 640x400.
* adding Objective-C properties and synthesize those that can.
* fixing the issue where `inputStyle` would never change due to always being `nil`, as well as retaining the new `inputStyle` via copying it (My code uses ARC, although copying it is to make sure the `ZStyle` wouldn't change. If the changing was desired, the `copy` can be replaced with a `retain` instead).